### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_local_action_basic.yml
+++ b/.github/workflows/test_local_action_basic.yml
@@ -18,6 +18,9 @@ on:
         required: true
         default: 3231cf1ec9439d1e3984c447b2ee51960ec523e3
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/security-report-action/security/code-scanning/13](https://github.com/advanced-security/security-report-action/security/code-scanning/13)

To address this issue, we should add a `permissions` block to the workflow or the affected job. Placing `permissions` at the root level ensures all jobs in the workflow default to the least privilege unless a job overrides them specifically. Given the analyzed steps only require read access to repository contents for checkout, and uploading an artifact does not require extra permissions on the repo, the minimal effective fix is to set `contents: read` at the root. Specifically:

- Insert a `permissions:` block *just above* the `jobs:` key (after input definitions and before jobs), e.g. after line 20.
- Set the value to `contents: read`.

No imports, method or variable definitions are needed, as this is only a configuration file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
